### PR TITLE
Fix /prefix/len bug 

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ app.get('/prefix/:pre/:len', function (req, res) {
     if (isNaN(req.params.len)) {
         res.status(400).send('must be a number\r\n').end();
     } else {
-        var length = req.params.pre.length + req.params.len;
+        var length =  parseInt(req.params.len) + parseInt(req.params.pre.length);
         res.status(200).send(genPass(length, false, '', req.params.pre) + '\r\n');
     }
 });


### PR DESCRIPTION
Calculates the length of the string passed to genPass based on the length of prefix and len argument instead of string lengths